### PR TITLE
Dc statehood option

### DIFF
--- a/states/states.py
+++ b/states/states.py
@@ -34,6 +34,12 @@ class States_Abbreviated:
     west_region = []
     west_region.extend(mountain + pacific)  
     
+    def __init__(self, is_DC_state):
+        if not is_DC_state:
+           self.south_atlantic.remove('DC')
+           self.all_states.remove('DC')
+           self.south_region.remove('DC')
+    
 class States_Full_Name:
     east_north_central = ['Illinois', 'Indiana', 'Michigan', 'Ohio', 'Wisconsin']
     
@@ -69,3 +75,9 @@ class States_Full_Name:
     
     west_region = []
     west_region.extend(mountain + pacific)  
+    
+    def __init__(self, is_DC_state):
+        if not is_DC_state:
+           self.south_atlantic.remove('District of Columbia')
+           self.all_states.remove('District of Columbia')
+           self.south_region.remove('District of Columbia')


### PR DESCRIPTION
Added DC statehood option to the class States_Abbreviated and States_Full_Name by adding a parameter into the constructor which defines whether or not to include DC as a state.